### PR TITLE
fix(cors): add graphql url to rewrites

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   ignoreDuringBuilds: true,
-}
+  async rewrites() {
+    return [
+      {
+        source: '/graphql/:path*',
+        destination: `https://graphql-gateway.axieinfinity.com/graphql/:path*`,
+      },
+    ];
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/utils/axie.ts
+++ b/utils/axie.ts
@@ -1,17 +1,14 @@
 export const getAxieGenes = async (axieId: string): Promise<string> => {
-  const fetcher = await fetch(
-    "https://graphql-gateway.axieinfinity.com/graphql",
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        operationName: "GetAxieDetail",
-        variables: { axieId },
-        query:
-          "query GetAxieDetail($axieId: ID!) {\n  axie(axieId: $axieId) { newGenes\n}\n}",
-      }),
-    }
-  );
+  const fetcher = await fetch("/graphql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "GetAxieDetail",
+      variables: { axieId },
+      query:
+        "query GetAxieDetail($axieId: ID!) {\n  axie(axieId: $axieId) { newGenes\n}\n}",
+    }),
+  });
   const res = await fetcher.json();
   return res?.data?.axie?.newGenes;
 };


### PR DESCRIPTION
hello, this adds a proxy from /graphql to https://graphql-gateway.axieinfinity.com/graphql to avoid cors errors on chrome, currently the apps is not working  as you can see here: https://mixer-playground-six.vercel.app/
![image](https://user-images.githubusercontent.com/1799851/195146597-d2b0e582-af49-46a3-9111-3cda0a879b11.png)

i've deployed this fix here https://axie-mixer-playground.vercel.app

![image](https://user-images.githubusercontent.com/1799851/195147226-abe7c075-2d44-4488-b654-6f2c3a55163d.png)
